### PR TITLE
Leave the stream open after writing

### DIFF
--- a/src/FsPdf/Pdf.fs
+++ b/src/FsPdf/Pdf.fs
@@ -115,7 +115,7 @@ module PdfObject =
         writer.Write System.Environment.NewLine
 
     let writePdf (stream:System.IO.Stream) (pdf:PdfObject list) =
-        use writer = new System.IO.StreamWriter (stream, leaveOpen = true)
+        use writer = new System.IO.StreamWriter (stream, System.Text.Encoding.UTF8, 1024, true)
         writePreamble (writer)
         let xrefs = ResizeArray<XRef>()
         pdf |> List.iter (fun p -> p |> writeSource writer xrefs; writer.WriteLine ())

--- a/src/FsPdf/Pdf.fs
+++ b/src/FsPdf/Pdf.fs
@@ -115,7 +115,7 @@ module PdfObject =
         writer.Write System.Environment.NewLine
 
     let writePdf (stream:System.IO.Stream) (pdf:PdfObject list) =
-        use writer = new System.IO.StreamWriter (stream)
+        use writer = new System.IO.StreamWriter (stream, leaveOpen = true)
         writePreamble (writer)
         let xrefs = ResizeArray<XRef>()
         pdf |> List.iter (fun p -> p |> writeSource writer xrefs; writer.WriteLine ())


### PR DESCRIPTION
The current behavior is causing problems when using an intermediary stream, because it gets closed when the function yields and then it's impossible to copy out the data.